### PR TITLE
JUnit 5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 
     <version.dc-commons>3.0.1</version.dc-commons>
     <version.javamelody>1.76.0</version.javamelody>
+    <version.junit-jupiter>5.4.0</version.junit-jupiter>
     <version.logstash-logback-encoder>5.3</version.logstash-logback-encoder>
     <version.spotbugs>3.1.11</version.spotbugs>
     <version.webjar-bootstrap>4.3.1</version.webjar-bootstrap>
@@ -144,12 +145,8 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${version.junit-jupiter}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR updates `junit-jupiter` to latest 5.4 version.

With the 5.4 series the `junit-jupiter` meta package can be used instead of `junit-jupiter-api` and `junit-jupiter-engine`.